### PR TITLE
media: Switch to lower-end codecs

### DIFF
--- a/configs/media_codecs.xml
+++ b/configs/media_codecs.xml
@@ -312,6 +312,6 @@ ___________________________________________________
             <Limit name="concurrent-instances" max="16" />
         </MediaCodec>
     </Decoders>
-    <Include href="media_codecs_google_video.xml" />
+    <Include href="media_codecs_google_video_le.xml" />
     <Include href="media_codecs_ffmpeg.xml" />
 </MediaCodecs>


### PR DESCRIPTION
Codecs such as HEVC 1080p aren't supported in the msm8916 platform (they are on msm8939), so we should use le instead.
Note that this change depends on http://review.cyanogenmod.org/#/c/162105/ being merged.
